### PR TITLE
Fix area light bounds on Lecaro/other moons

### DIFF
--- a/RuntimeIcons/src/Components/CameraQueueComponent.cs
+++ b/RuntimeIcons/src/Components/CameraQueueComponent.cs
@@ -46,8 +46,18 @@ public class CameraQueueComponent : MonoBehaviour
         };
         _computingThread.Start();
         StageCamera = Stage.Camera;
+    }
+
+    private void OnEnable()
+    {
         RenderPipelineManager.beginCameraRendering += OnBeginCameraRendering;
         RenderPipelineManager.endCameraRendering += OnEndCameraRendering;
+    }
+
+    private void OnDisable()
+    {
+        RenderPipelineManager.beginCameraRendering -= OnBeginCameraRendering;
+        RenderPipelineManager.endCameraRendering -= OnEndCameraRendering;
     }
 
     private void ComputeThread()

--- a/RuntimeIcons/src/Components/CameraQueueComponent.cs
+++ b/RuntimeIcons/src/Components/CameraQueueComponent.cs
@@ -465,6 +465,7 @@ public class CameraQueueComponent : MonoBehaviour
             if (_isolatorHolder != null)
             {
                 var holder = _isolatorHolder;
+                // Remove the isolator before disposing in case an exception is encountered.
                 _isolatorHolder = null;
                 holder.Dispose();
             }

--- a/RuntimeIcons/src/Components/CameraQueueComponent.cs
+++ b/RuntimeIcons/src/Components/CameraQueueComponent.cs
@@ -683,7 +683,11 @@ public class CameraQueueComponent : MonoBehaviour
             _ambientLight = null;
 
             foreach (var light in _disabledLights)
+            {
                 light.enabled = true;
+                if (light.TryGetComponent(out HDAdditionalLightData lightData))
+                    lightData.UpdateBounds();
+            }
 
             _disabledLights.Clear();
             _localLights.Clear();

--- a/RuntimeIcons/src/Components/StageComponent.cs
+++ b/RuntimeIcons/src/Components/StageComponent.cs
@@ -165,10 +165,16 @@ public class StageComponent : MonoBehaviour
         };
     }
 
-    private void Awake()
+    private void OnEnable()
     {
         HDRenderPipelinePatch.beginCameraRendering += BeginCameraRendering;
         RenderPipelineManager.endCameraRendering += EndCameraRendering;
+    }
+
+    private void OnDisable()
+    {
+        HDRenderPipelinePatch.beginCameraRendering -= BeginCameraRendering;
+        RenderPipelineManager.endCameraRendering -= EndCameraRendering;
     }
 
     internal void SetStageFromSettings(StageSettings stageSettings)

--- a/RuntimeIcons/src/Components/StageComponent.cs
+++ b/RuntimeIcons/src/Components/StageComponent.cs
@@ -556,51 +556,6 @@ public class StageComponent : MonoBehaviour
         SetAlphaEnabled(false);
     }
 
-    internal class IsolateStageLights : IDisposable
-    {
-        private List<Light> _lightMemory;
-        private Color _ambientLight;
-
-        public IsolateStageLights(params GameObject[] stageObjects)
-        {
-            _lightMemory = UnityEngine.Pool.ListPool<Light>.Get();
-
-            _ambientLight = RenderSettings.ambientLight;
-            RenderSettings.ambientLight = Color.black;
-
-            var localLights = UnityEngine.Pool.ListPool<Light>.Get();
-            foreach (var stageObject in stageObjects)
-                localLights.AddRange(stageObject.GetComponentsInChildren<Light>());
-
-            foreach (var light in FindObjectsByType<Light>(FindObjectsSortMode.None))
-            {
-                if (!light.enabled)
-                    continue;
-                if (localLights.Contains(light))
-                    continue;
-                _lightMemory.Add(light);
-                light.enabled = false;
-            }
-
-            UnityEngine.Pool.ListPool<Light>.Release(localLights);
-        }
-
-        public void Dispose()
-        {
-            if (_lightMemory == null)
-                return;
-
-            RenderSettings.ambientLight = _ambientLight;
-            _ambientLight = Color.black;
-
-            foreach (var light in _lightMemory)
-                light.enabled = true;
-
-            ListPool<Light>.Release(_lightMemory);
-            _lightMemory = null;
-        }
-    }
-
     internal record struct TransformMemory
     {
         public readonly Transform Parent;

--- a/RuntimeIcons/src/RuntimeIcons.cs
+++ b/RuntimeIcons/src/RuntimeIcons.cs
@@ -82,7 +82,10 @@ public class RuntimeIcons : BaseUnityPlugin
             Log.LogInfo("Patching Methods");
 
             StartOfRoundPatch.Init();
-            Harmony.PatchAll();
+            Harmony.PatchAll(typeof(HDRenderPipelinePatch));
+            Harmony.PatchAll(typeof(MenuManagerPatch));
+            Harmony.PatchAll(typeof(StartOfRoundPatch));
+            Harmony.PatchAll(typeof(GrabbableObjectPatch));
 
             Log.LogInfo(NAME + " v" + VERSION + " Loaded!");
 


### PR DESCRIPTION
Apparently HDRP wasn't recalculating area light bounds properly when we disable/enable them in camera callbacks... Very strange.